### PR TITLE
[Feature] 코드 변경 사항(Diff) 감지 및 시각화 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,15 +68,18 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.105.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
+    "@types/vscode": "^1.105.0",
     "@typescript-eslint/eslint-plugin": "^8.45.0",
     "@typescript-eslint/parser": "^8.45.0",
-    "eslint": "^9.36.0",
-    "typescript": "^5.9.3",
     "@vscode/test-cli": "^0.0.11",
-    "@vscode/test-electron": "^2.5.2"
+    "@vscode/test-electron": "^2.5.2",
+    "eslint": "^9.36.0",
+    "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "dependencies": {
+    "diff": "^8.0.4"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      diff:
+        specifier: ^8.0.4
+        version: 8.0.4
     devDependencies:
       '@types/mocha':
         specifier: ^10.0.10
@@ -354,6 +358,10 @@ packages:
 
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   eastasianwidth@0.2.0:
@@ -1319,6 +1327,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   diff@7.0.0: {}
+
+  diff@8.0.4: {}
 
   eastasianwidth@0.2.0: {}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,9 @@ export function activate(context: vscode.ExtensionContext) {
 
   // 텍스트 선택 감지 등록
   registerTextSelectionListener(context, provider);
+
+  // 저장 시 diff 생성 등록
+  registerSaveListener(context, provider);
 }
 
 /**
@@ -79,6 +82,20 @@ function registerTextSelectionListener(
           provider.sendSelectedCode();
         }, 800);
       }
+    }),
+  );
+}
+
+/**
+ * 저장 이벤트 감지
+ */
+function registerSaveListener(
+  context: vscode.ExtensionContext,
+  provider: ClogSidebarProvider,
+) {
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((document) => {
+      provider.handleDocumentSave(document);
     }),
   );
 }

--- a/src/providers/ClogSidebarProvider.ts
+++ b/src/providers/ClogSidebarProvider.ts
@@ -1,7 +1,16 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
+import { createPatch } from "diff";
 import { openPreviewPanel } from "../utils/previewPanel";
+
+interface CodeSnapshot {
+  fileName: string;
+  filePath: string;
+  languageId: string;
+  content: string;
+  savedAt: string;
+}
 
 /**
  * 사이드바 Webview Provider 클래스
@@ -9,11 +18,17 @@ import { openPreviewPanel } from "../utils/previewPanel";
  */
 export class ClogSidebarProvider implements vscode.WebviewViewProvider {
   public view?: vscode.WebviewView;
+  private readonly _snapshotFileUri: vscode.Uri;
 
   constructor(
     private readonly _extensionUri: vscode.Uri,
-    private readonly _context: vscode.ExtensionContext
-  ) {}
+    private readonly _context: vscode.ExtensionContext,
+  ) {
+    this._snapshotFileUri = vscode.Uri.joinPath(
+      this._context.storageUri ?? this._context.globalStorageUri,
+      "clog-snapshot.json",
+    );
+  }
 
   /**
    * Webview 뷰가 생성될 때 호출
@@ -21,7 +36,7 @@ export class ClogSidebarProvider implements vscode.WebviewViewProvider {
   resolveWebviewView(
     webviewView: vscode.WebviewView,
     context: vscode.WebviewViewResolveContext,
-    _token: vscode.CancellationToken
+    _token: vscode.CancellationToken,
   ) {
     this.view = webviewView;
 
@@ -34,6 +49,17 @@ export class ClogSidebarProvider implements vscode.WebviewViewProvider {
 
     // 웹뷰로부터 메시지 받기
     this._setWebviewMessageListener(webviewView);
+
+    const snapshot = this._loadSnapshot();
+    if (snapshot) {
+      this._postMessage({
+        type: "snapshotReady",
+        fileName: snapshot.fileName,
+        filePath: snapshot.filePath,
+        language: snapshot.languageId,
+        savedAt: snapshot.savedAt,
+      });
+    }
   }
 
   /**
@@ -42,6 +68,28 @@ export class ClogSidebarProvider implements vscode.WebviewViewProvider {
   private _setWebviewMessageListener(webviewView: vscode.WebviewView) {
     webviewView.webview.onDidReceiveMessage((message) => {
       switch (message.type) {
+        case "loginSuccess":
+          this._storeActiveDocumentSnapshot();
+          break;
+        case "requestSnapshotState": {
+          const snapshot = this._loadSnapshot();
+
+          if (snapshot) {
+            this._postMessage({
+              type: "snapshotReady",
+              fileName: snapshot.fileName,
+              filePath: snapshot.filePath,
+              language: snapshot.languageId,
+              savedAt: snapshot.savedAt,
+            });
+          } else {
+            this._postMessage({
+              type: "snapshotMissing",
+              message: "로그인 후 기준 코드가 아직 저장되지 않았습니다.",
+            });
+          }
+          break;
+        }
         case "requestCode":
           this.sendSelectedCode();
           break;
@@ -83,6 +131,101 @@ export class ClogSidebarProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  public handleDocumentSave(document: vscode.TextDocument) {
+    const snapshot = this._loadSnapshot();
+
+    if (!snapshot || snapshot.filePath !== document.fileName) {
+      return;
+    }
+
+    const currentContent = document.getText();
+
+    if (snapshot.content === currentContent) {
+      this._postMessage({
+        type: "documentUnchanged",
+        fileName: snapshot.fileName,
+        filePath: snapshot.filePath,
+      });
+      return;
+    }
+
+    const patch = createPatch(
+      snapshot.fileName,
+      snapshot.content,
+      currentContent,
+      "stored snapshot",
+      "current save",
+    );
+
+    this._postMessage({
+      type: "documentDiff",
+      fileName: snapshot.fileName,
+      filePath: snapshot.filePath,
+      patch,
+      savedAt: new Date().toISOString(),
+    });
+  }
+
+  private _storeActiveDocumentSnapshot() {
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+      this._postMessage({
+        type: "snapshotError",
+        message:
+          "저장할 활성 편집기가 없습니다. 코드 파일을 연 뒤 다시 로그인해주세요.",
+      });
+      return;
+    }
+
+    const document = editor.document;
+    const snapshot: CodeSnapshot = {
+      fileName: path.basename(document.fileName),
+      filePath: document.fileName,
+      languageId: document.languageId,
+      content: document.getText(),
+      savedAt: new Date().toISOString(),
+    };
+
+    this._saveSnapshot(snapshot);
+
+    this._postMessage({
+      type: "snapshotReady",
+      fileName: snapshot.fileName,
+      filePath: snapshot.filePath,
+      language: snapshot.languageId,
+      savedAt: snapshot.savedAt,
+    });
+  }
+
+  private _saveSnapshot(snapshot: CodeSnapshot) {
+    fs.mkdirSync(path.dirname(this._snapshotFileUri.fsPath), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      this._snapshotFileUri.fsPath,
+      JSON.stringify(snapshot, null, 2),
+      "utf8",
+    );
+  }
+
+  private _loadSnapshot(): CodeSnapshot | null {
+    if (!fs.existsSync(this._snapshotFileUri.fsPath)) {
+      return null;
+    }
+
+    try {
+      const fileContent = fs.readFileSync(this._snapshotFileUri.fsPath, "utf8");
+      return JSON.parse(fileContent) as CodeSnapshot;
+    } catch {
+      return null;
+    }
+  }
+
+  private _postMessage(message: Record<string, unknown>) {
+    this.view?.webview.postMessage(message);
+  }
+
   /**
    * HTML 로드 및 경로 변환
    */
@@ -91,7 +234,7 @@ export class ClogSidebarProvider implements vscode.WebviewViewProvider {
       this._extensionUri,
       "webview-ui",
       "dist",
-      "index.html"
+      "index.html",
     );
 
     let htmlContent: string;
@@ -108,7 +251,7 @@ export class ClogSidebarProvider implements vscode.WebviewViewProvider {
     }
 
     const distUri = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, "webview-ui", "dist")
+      vscode.Uri.joinPath(this._extensionUri, "webview-ui", "dist"),
     );
 
     // Asset 경로 변환

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,11 @@
 		"lib": [
 			"ES2022"
 		],
+		"types": [
+			"mocha",
+			"node",
+			"vscode"
+		],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -6,8 +6,11 @@ function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const handleLogin = () => {
-    // TODO: VS Code extension과 통신하여 실제 GitHub 로그인 처리
-    console.log('GitHub 로그인 요청');
+    if (!window.vscode && typeof window.acquireVsCodeApi === 'function') {
+      window.vscode = window.acquireVsCodeApi();
+    }
+
+    window.vscode?.postMessage({ type: 'loginSuccess' });
     setIsLoggedIn(true);
   };
 

--- a/webview-ui/src/pages/Editor/EditorScreen.tsx
+++ b/webview-ui/src/pages/Editor/EditorScreen.tsx
@@ -231,6 +231,71 @@ const EmptyState = styled.div`
   }
 `;
 
+const DiffPanel = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  border: 1px solid #3e3e42;
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(14, 99, 156, 0.18), rgba(30, 30, 30, 0.92));
+`;
+
+const DiffPanelHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+`;
+
+const DiffPanelTitle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  h2 {
+    font-size: 0.98rem;
+    font-weight: 600;
+    color: #ffffff;
+  }
+
+  p {
+    font-size: 0.8rem;
+    color: #9da4ad;
+    line-height: 1.4;
+  }
+`;
+
+const DiffStatusBadge = styled.span<{ $tone: 'idle' | 'success' | 'warning' | 'error' }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+  border: 1px solid
+    ${props => props.$tone === 'success' ? '#2da44e' : props.$tone === 'warning' ? '#d29922' : props.$tone === 'error' ? '#f85149' : '#3e3e42'};
+  color: ${props => props.$tone === 'success' ? '#7ee787' : props.$tone === 'warning' ? '#f2cc60' : props.$tone === 'error' ? '#ffa198' : '#c9d1d9'};
+  background: ${props => props.$tone === 'success' ? 'rgba(45, 164, 78, 0.14)' : props.$tone === 'warning' ? 'rgba(210, 153, 34, 0.12)' : props.$tone === 'error' ? 'rgba(248, 81, 73, 0.12)' : 'rgba(110, 118, 129, 0.12)'};
+`;
+
+const DiffPanelBody = styled.pre`
+  margin: 0;
+  padding: 0.9rem;
+  border-radius: 8px;
+  background: #0f111a;
+  border: 1px solid #2d333b;
+  color: #c9d1d9;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+  max-height: 240px;
+`;
+
 interface Message {
   id: string;
   role: 'user' | 'assistant';
@@ -246,6 +311,13 @@ interface Attachment {
   data: string;
 }
 
+interface DiffState {
+  title: string;
+  details: string;
+  content: string;
+  tone: 'idle' | 'success' | 'warning' | 'error';
+}
+
 export default function EditorScreen() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
@@ -253,19 +325,28 @@ export default function EditorScreen() {
   const [pendingCode, setPendingCode] = useState<Attachment | null>(null);
   const [isThinking, setIsThinking] = useState(false);
   const [thinkingSteps, setThinkingSteps] = useState<string[]>([]);
+  const [snapshotSummary, setSnapshotSummary] = useState('로그인하면 현재 열린 코드의 스냅샷을 저장합니다.');
+  const [diffState, setDiffState] = useState<DiffState>({
+    title: 'diff 대기 중',
+    details: 'Ctrl+S를 누르면 저장된 기준 코드와 현재 코드의 차이를 보여줍니다.',
+    content: '로그인 후 기준 코드가 저장되면 여기에 diff가 표시됩니다.',
+    tone: 'idle',
+  });
 
   // VS Code API 초기화
   useEffect(() => {
     if (typeof window.acquireVsCodeApi === 'function' && !window.vscode) {
       window.vscode = window.acquireVsCodeApi();
     }
+
+    window.vscode?.postMessage({ type: 'requestSnapshotState' });
   }, []);
 
   // VS Code extension으로부터 메시지 받기
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const message = event.data;
-      
+
       if (message.type === 'codePending') {
         // Extension에서 보낸 코드를 임시 칩으로 표시 (아직 추가 안됨)
         const tempAttachment: Attachment = {
@@ -275,6 +356,61 @@ export default function EditorScreen() {
           data: message.code,
         };
         setPendingCode(tempAttachment);
+        return;
+      }
+
+      if (message.type === 'snapshotReady') {
+        setSnapshotSummary(`${message.fileName} 기준 코드를 저장했습니다.`);
+        setDiffState({
+          title: `${message.fileName} 저장 기준 준비됨`,
+          details: `파일: ${message.filePath ?? message.fileName}`,
+          content: '이후 Ctrl+S를 누르면 baseline과 현재 코드의 diff가 여기에 표시됩니다.',
+          tone: 'success',
+        });
+        return;
+      }
+
+      if (message.type === 'documentDiff') {
+        setSnapshotSummary(`${message.fileName} 저장 완료. diff를 갱신했습니다.`);
+        setDiffState({
+          title: `${message.fileName} diff`,
+          details: `마지막 저장: ${new Date(message.savedAt).toLocaleString('ko-KR')}`,
+          content: message.patch || 'diff를 생성했지만 결과가 비어 있습니다.',
+          tone: 'warning',
+        });
+        return;
+      }
+
+      if (message.type === 'documentUnchanged') {
+        setSnapshotSummary(`${message.fileName} 저장 완료. 변경 사항이 없습니다.`);
+        setDiffState({
+          title: `${message.fileName} 변경 없음`,
+          details: '저장된 기준 코드와 현재 코드가 동일합니다.',
+          content: '현재 저장된 코드와 스냅샷이 완전히 같습니다.',
+          tone: 'idle',
+        });
+        return;
+      }
+
+      if (message.type === 'snapshotError') {
+        setSnapshotSummary(message.message);
+        setDiffState({
+          title: '기준 코드 저장 실패',
+          details: '활성 편집기를 찾지 못했습니다.',
+          content: message.message,
+          tone: 'error',
+        });
+        return;
+      }
+
+      if (message.type === 'snapshotMissing') {
+        setSnapshotSummary(message.message);
+        setDiffState({
+          title: '기준 코드 대기 중',
+          details: '로그인 후 기준 코드를 저장해야 diff를 볼 수 있습니다.',
+          content: message.message,
+          tone: 'idle',
+        });
       }
     };
 
@@ -355,6 +491,26 @@ export default function EditorScreen() {
   return (
     <EditorContainer>
       <Content>
+        <DiffPanel>
+          <DiffPanelHeader>
+            <DiffPanelTitle>
+              <h2>{diffState.title}</h2>
+              <p>{diffState.details}</p>
+            </DiffPanelTitle>
+            <DiffStatusBadge $tone={diffState.tone}>
+              {diffState.tone === 'success'
+                ? 'baseline 저장'
+                : diffState.tone === 'warning'
+                  ? 'diff 생성'
+                  : diffState.tone === 'error'
+                    ? '에러'
+                    : '대기 중'}
+            </DiffStatusBadge>
+          </DiffPanelHeader>
+          <div style={{ fontSize: '0.82rem', color: '#9da4ad' }}>{snapshotSummary}</div>
+          <DiffPanelBody>{diffState.content}</DiffPanelBody>
+        </DiffPanel>
+
         <ConversationArea>
           {messages.length === 0 ? (
             <EmptyState>


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
### 1️⃣ 초기 데이터 백업 (Base 설정)
트리거: 로그인 성공 시점

작업: - 현재 활성화된 에디터 혹은 프로젝트의 전체 소스 코드를 로드합니다.

extensionContext.storageUri 경로에 original_code.txt (또는 원본 파일명)로 백업본을 생성하여 비교 기준점(Base)을 마련합니다.

### 2️⃣ 변경 사항 추출 로직 (Diff Generation)
이벤트: vscode.workspace.onDidSaveTextDocument 리스너 등록

비교 대상:

Storage: storageUri에 저장된 원본 코드

Current: 현재 에디터에서 방금 저장된 최신 코드

로직: diff 라이브러리의 createPatch 함수를 사용하여 Unified Diff 포맷의 데이터를 생성합니다.

### 3️⃣ Diff 시각화 (UI/UX)
생성된 patch 데이터를 사용자에게 친숙한 UI로 출력합니다.

[우선순위 1] Webview Panel: diff2html 라이브러리를 활용해 사이드 바이 사이드(Side-by-Side) 또는 라인별(Line-by-Line) 뷰를 제공합니다.

[우선순위 2] Virtual Document: 웹뷰 구현 전 단계에서 텍스트 기반의 가상 문서를 열어 Diff 내용을 단순 출력합니다.
## 🎯 작업 목적

<!-- 왜 이 작업이 필요했는지 설명해주세요 -->
<!-- 관련된 이슈가 있다면 링크를 걸어주세요: -->

Closes #6 

## 🔍 변경 내용

<!-- 구체적으로 어떤 파일/기능을 수정했는지 체크리스트로 작성해주세요 -->

- [ ] 기능 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 스타일 변경
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 기타 (설명: )

## 📸 스크린샷 (선택)

<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

<img width="529" height="420" alt="스크린샷 2026-04-03 오후 9 41 05" src="https://github.com/user-attachments/assets/bcb92079-cf91-4151-b823-a010c0823397" />

## ✅ 테스트 체크리스트

- [ ] 로컬에서 정상 작동 확인
- [ ] 빌드 성공 확인 (`pnpm run compile` / `pnpm run webview:build`)
- [ ] Extension Development Host에서 테스트 완료
- [ ] 기존 기능에 영향 없음 확인

## 💬 리뷰어에게

<!-- 리뷰어가 특히 집중해서 봐야 할 부분이나 궁금한 점을 적어주세요 -->

## 📚 참고 자료 (선택)

<!-- 관련 문서, 레퍼런스 등이 있다면 링크를 추가해주세요 -->
